### PR TITLE
2.13 for real

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val Scala_213 = "2.13.0" //don't use 2.13.1 until kind-projector is fixed
 
 val catsEffectVersion = "2.0.0"
 val catsTaglessVersion = "0.10"
-val doobieVersion = "0.8.2"
+val doobieVersion = "0.8.4"
 val catsVersion = "2.0.0"
 val scalacacheVersion = "0.28.0"
 val kindProjectorVersion = "0.10.3"
@@ -43,7 +43,7 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-tagless-laws" % catsTaglessVersion % Test,
     "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % Test,
-    "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-M2" % Test,
+    "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-RC1" % Test,
     "org.typelevel" %% "cats-laws" % catsVersion % Test,
     "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test
   ) ++ compilerPlugins,

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,19 @@
-val Scala_212 = "2.12.8"
-val Scala_211 = "2.11.11"
+val Scala_212 = "2.12.10"
+val Scala_213 = "2.13.0"
 
-val catsEffectVersion          = "1.4.0"
-val catsTaglessVersion         = "0.5"
-val catsParVersion             = "0.2.1"
-val doobieVersion              = "0.7.0"
-val catsVersion                = "1.6.1"
-val scalacheckShapelessVersion = "1.1.8"
-val scalatestVersion           = "3.0.8"
-val simulacrumVersion          = "1.0.0"
-val scalacacheVersion          = "0.28.0"
-val macroParadiseVersion       = "2.1.1"
-val kindProjectorVersion       = "0.10.3"
-val refinedVersion             = "0.9.10"
-val fs2RedisVersion            = "0.9.0"
-val h2Version                  = "1.4.199"
-val log4CatsVersion            = "0.3.0"
-val http4sVersion              = "0.20.11"
-val circeVersion               = "0.11.1"
-val sttpVersion                = "1.6.7"
+val catsEffectVersion = "2.0.0"
+val catsTaglessVersion = "0.10"
+val doobieVersion = "0.8.2"
+val catsVersion = "2.0.0"
+val scalacheckMagnoliaVersion = "0.3.0"
+val scalacacheVersion = "0.28.0"
+val kindProjectorVersion = "0.10.3"
+val fs2RedisVersion = "0.9.0"
+val h2Version = "1.4.199"
+val log4CatsVersion = "1.0.0"
+val http4sVersion = "0.21.0-M4"
+val circeVersion = "0.12.1"
+val sttpVersion = "1.6.7"
 
 inThisBuild(
   List(
@@ -33,44 +28,39 @@ inThisBuild(
         url("https://kubukoz.com")
       )
     )
-  ))
+  )
+)
 
 val compilerPlugins = List(
-  compilerPlugin("org.scalamacros" % "paradise" % macroParadiseVersion).cross(CrossVersion.full),
   compilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorVersion)
 )
 
 val commonSettings = Seq(
   scalaVersion := Scala_212,
-  scalacOptions ++= Options.all,
+  scalacOptions ++= Options.all(scalaVersion.value),
   fork in Test := true,
   name := "sup",
   updateOptions := updateOptions.value.withGigahorse(false), //may fix publishing bug
   libraryDependencies ++= Seq(
-    "org.typelevel"              %% "cats-tagless-laws"         % catsTaglessVersion         % Test,
-    "org.typelevel"              %% "cats-effect-laws"          % catsEffectVersion          % Test,
-    "org.typelevel"              %% "cats-testkit"              % catsVersion                % Test,
-    "org.typelevel"              %% "cats-laws"                 % catsVersion                % Test,
-    "org.typelevel"              %% "cats-kernel-laws"          % catsVersion                % Test,
-    "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % scalacheckShapelessVersion % Test,
-    "org.scalatest"              %% "scalatest"                 % scalatestVersion           % Test
+    "org.typelevel" %% "cats-tagless-laws" % catsTaglessVersion % Test,
+    "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % Test,
+    "org.typelevel" %% "cats-testkit" % catsVersion % Test,
+    "org.typelevel" %% "cats-laws" % catsVersion % Test,
+    "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test,
+    "com.github.chocpanda" %% "scalacheck-magnolia" % scalacheckMagnoliaVersion % Test,
+    "org.scalatest" %% "scalatest" % scalatestVersion % Test
   ) ++ compilerPlugins,
-  mimaPreviousArtifacts := Set(organization.value %% name.value.toLowerCase % "0.2.0")
+  mimaPreviousArtifacts := Set()
 )
 
-val crossBuiltCommonSettings = commonSettings ++ Seq(crossScalaVersions := Seq(Scala_211, Scala_212))
+val crossBuiltCommonSettings = commonSettings ++ Seq(crossScalaVersions := Seq(Scala_212, Scala_213))
 
 def module(moduleName: String): Project =
-  Project(moduleName, file("modules/" + moduleName))
-    .settings(crossBuiltCommonSettings)
-    .settings(name += s"-$moduleName")
+  Project(moduleName, file("modules/" + moduleName)).settings(crossBuiltCommonSettings).settings(name += s"-$moduleName")
 
 val core = module("core").settings(
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "simulacrum"        % simulacrumVersion,
-    "org.typelevel"        %% "cats-effect"       % catsEffectVersion,
-    "io.chrisdavenport"    %% "cats-par"          % catsParVersion,
-    "org.typelevel"        %% "cats-tagless-core" % catsTaglessVersion
+
   )
 )
 
@@ -85,16 +75,14 @@ val scalacache = module("scalacache")
 val doobie = module("doobie")
   .settings(
     libraryDependencies ++= Seq(
-      "org.tpolecat"   %% "doobie-core" % doobieVersion,
-      "eu.timepit"     %% "refined"     % refinedVersion,
-      "com.h2database" % "h2"           % h2Version % Test
+      "org.tpolecat" %% "doobie-core" % doobieVersion,
+      "com.h2database" % "h2" % h2Version % Test
     )
   )
   .dependsOn(core % "compile->compile;test->test")
 
 val redis = module("redis")
   .settings(
-    crossScalaVersions := List(Scala_212),
     libraryDependencies ++= Seq(
       "dev.profunktor" %% "redis4cats-effects" % fs2RedisVersion
     )
@@ -104,8 +92,7 @@ val redis = module("redis")
 val log4cats = module("log4cats")
   .settings(
     libraryDependencies ++= Seq(
-      "io.chrisdavenport" %% "log4cats-core"   % log4CatsVersion,
-      "io.chrisdavenport" %% "log4cats-extras" % log4CatsVersion % Test
+      "io.chrisdavenport" %% "log4cats-core" % log4CatsVersion
     )
   )
   .dependsOn(core)
@@ -114,7 +101,7 @@ val http4s = module("http4s")
   .settings(
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-core" % http4sVersion,
-      "org.http4s" %% "http4s-dsl"  % http4sVersion
+      "org.http4s" %% "http4s-dsl" % http4sVersion
     )
   )
   .dependsOn(core)
@@ -149,7 +136,7 @@ val lastStableVersion = settingKey[String]("Last tagged version")
 
 val microsite = project
   .settings(
-    scalaVersion := "2.12.8",
+    scalaVersion := Scala_212,
     crossScalaVersions := List(),
     micrositeName := "sup",
     micrositeDescription := "Functional healthchecks in Scala",
@@ -163,18 +150,21 @@ val microsite = project
     micrositeGithubToken := sys.env.get("GITHUB_TOKEN"),
     //doesn't fork anyway though
     fork in makeMicrosite := true,
-    scalacOptions ++= Options.all,
+    scalacOptions ++= Options.all(scalaVersion.value),
     scalacOptions --= Seq("-Ywarn-unused:imports"),
     libraryDependencies ++= compilerPlugins,
     libraryDependencies ++= Seq(
       "io.chrisdavenport" %% "log4cats-extras" % log4CatsVersion,
-      "org.http4s"        %% "http4s-circe"    % http4sVersion
+      "org.http4s" %% "http4s-circe" % http4sVersion
     ),
     skip in publish := true,
     buildInfoPackage := "sup.buildinfo",
     micrositeAnalyticsToken := "UA-55943015-9",
     buildInfoKeys := Seq[BuildInfoKey](lastStableVersion),
-    lastStableVersion := dynverGitDescribeOutput.value.map(_.ref.value.tail).getOrElse(throw new Exception("There's no output from dynver!"))
+    lastStableVersion := dynverGitDescribeOutput
+      .value
+      .map(_.ref.value.tail)
+      .getOrElse(throw new Exception("There's no output from dynver!"))
   )
   .enablePlugins(MicrositesPlugin)
   .dependsOn(allModules.map(x => x: ClasspathDep[ProjectReference]): _*)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val Scala_212 = "2.12.10"
-val Scala_213 = "2.13.0"
+val Scala_213 = "2.13.1"
 
 val catsEffectVersion = "2.0.0"
 val catsTaglessVersion = "0.10"
@@ -11,7 +11,7 @@ val kindProjectorVersion = "0.10.3"
 val fs2RedisVersion = "0.9.0"
 val h2Version = "1.4.199"
 val log4CatsVersion = "1.0.0"
-val http4sVersion = "0.21.0-M5"
+val http4sVersion = "0.20.11"
 val circeVersion = "0.12.1"
 val sttpVersion = "1.6.7"
 
@@ -44,7 +44,6 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-tagless-laws" % catsTaglessVersion % Test,
     "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % Test,
-    "org.typelevel" %% "cats-testkit" % catsVersion % Test,
     "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-M2" % Test,
     "org.typelevel" %% "cats-laws" % catsVersion % Test,
     "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 val Scala_212 = "2.12.10"
-val Scala_213 = "2.13.0" //don't use 2.13.1 until kind-projector is fixed
+val Scala_213 = "2.13.1"
 
 val catsEffectVersion = "2.0.0"
 val catsTaglessVersion = "0.10"
 val doobieVersion = "0.8.4"
 val catsVersion = "2.0.0"
 val scalacacheVersion = "0.28.0"
-val kindProjectorVersion = "0.10.3"
+val kindProjectorVersion = "0.11.0"
 val fs2RedisVersion = "0.9.0"
 val h2Version = "1.4.199"
 val log4CatsVersion = "1.0.0"
@@ -31,7 +31,7 @@ inThisBuild(
 )
 
 val compilerPlugins = List(
-  compilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorVersion)
+  compilerPlugin("org.typelevel" % "kind-projector" % kindProjectorVersion cross CrossVersion.full)
 )
 
 val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,7 @@ val commonSettings = Seq(
     "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-M2" % Test,
     "org.typelevel" %% "cats-laws" % catsVersion % Test,
     "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test,
-    "com.github.chocpanda" %% "scalacheck-magnolia" % scalacheckMagnoliaVersion % Test,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test
+    "com.github.chocpanda" %% "scalacheck-magnolia" % scalacheckMagnoliaVersion % Test
   ) ++ compilerPlugins,
   mimaPreviousArtifacts := Set()
 )

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,6 @@ val microsite = project
     scalacOptions --= Seq("-Ywarn-unused:imports"),
     libraryDependencies ++= compilerPlugins,
     libraryDependencies ++= Seq(
-      "io.chrisdavenport" %% "log4cats-extras" % log4CatsVersion,
       "org.http4s" %% "http4s-circe" % http4sVersion
     ),
     skip in publish := true,

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val kindProjectorVersion = "0.10.3"
 val fs2RedisVersion = "0.9.0"
 val h2Version = "1.4.199"
 val log4CatsVersion = "1.0.0"
-val http4sVersion = "0.21.0-M4"
+val http4sVersion = "0.21.0-M5"
 val circeVersion = "0.12.1"
 val sttpVersion = "1.6.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val kindProjectorVersion = "0.10.3"
 val fs2RedisVersion = "0.9.0"
 val h2Version = "1.4.199"
 val log4CatsVersion = "1.0.0"
-val http4sVersion = "0.20.11"
+val http4sVersion = "0.21.0-M5"
 val circeVersion = "0.12.1"
 val sttpVersion = "1.6.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ val catsEffectVersion = "2.0.0"
 val catsTaglessVersion = "0.10"
 val doobieVersion = "0.8.2"
 val catsVersion = "2.0.0"
-val scalacheckMagnoliaVersion = "0.3.0"
 val scalacacheVersion = "0.28.0"
 val kindProjectorVersion = "0.10.3"
 val fs2RedisVersion = "0.9.0"
@@ -46,8 +45,7 @@ val commonSettings = Seq(
     "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % Test,
     "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-M2" % Test,
     "org.typelevel" %% "cats-laws" % catsVersion % Test,
-    "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test,
-    "com.github.chocpanda" %% "scalacheck-magnolia" % scalacheckMagnoliaVersion % Test
+    "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test
   ) ++ compilerPlugins,
   mimaPreviousArtifacts := Set()
 )
@@ -59,7 +57,8 @@ def module(moduleName: String): Project =
 
 val core = module("core").settings(
   libraryDependencies ++= Seq(
-
+    "org.typelevel" %% "cats-effect" % catsEffectVersion,
+    "org.typelevel" %% "cats-tagless-core" % catsTaglessVersion
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val Scala_212 = "2.12.10"
-val Scala_213 = "2.13.1"
+val Scala_213 = "2.13.0" //don't use 2.13.1 until kind-projector is fixed
 
 val catsEffectVersion = "2.0.0"
 val catsTaglessVersion = "0.10"

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val commonSettings = Seq(
 val crossBuiltCommonSettings = commonSettings ++ Seq(crossScalaVersions := Seq(Scala_212, Scala_213))
 
 def module(moduleName: String): Project =
-  Project(moduleName, file("modules/" + moduleName)).settings(crossBuiltCommonSettings).settings(name += s"-$moduleName")
+  Project(moduleName, file("modules") / moduleName).settings(crossBuiltCommonSettings).settings(name += s"-$moduleName")
 
 val core = module("core").settings(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ val commonSettings = Seq(
     "org.typelevel" %% "cats-tagless-laws" % catsTaglessVersion % Test,
     "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % Test,
     "org.typelevel" %% "cats-testkit" % catsVersion % Test,
+    "org.typelevel" %% "cats-testkit-scalatest" % "1.0.0-M2" % Test,
     "org.typelevel" %% "cats-laws" % catsVersion % Test,
     "org.typelevel" %% "cats-kernel-laws" % catsVersion % Test,
     "com.github.chocpanda" %% "scalacheck-magnolia" % scalacheckMagnoliaVersion % Test,

--- a/microsite/src/main/tut/guide/doobie.md
+++ b/microsite/src/main/tut/guide/doobie.md
@@ -29,6 +29,7 @@ def transactor: Transactor[IO] = ???
 And now the health check:
 
 ```tut:book
-import eu.timepit.refined.auto._
-def doobieCheck = connectionCheck(transactor)(timeoutSeconds = Some(5))
+import scala.concurrent.duration._
+
+def doobieCheck = connectionCheck(transactor)(timeout = Some(5.seconds))
 ```

--- a/microsite/src/main/tut/guide/http4s-circe.md
+++ b/microsite/src/main/tut/guide/http4s-circe.md
@@ -26,11 +26,14 @@ The circe module provides circe `Encoder`/`Decoder` instances for all the import
 so you can use them together with `http4s-circe` and bundle the whole thing up:
 
 ```tut:book
-import io.circe._, org.http4s.circe._, org.http4s._, org.http4s.implicits._, org.http4s.client._, org.http4s.circe.CirceEntityEncoder._, org.http4s.circe.CirceEntityDecoder._
+import io.circe._, org.http4s.circe._, org.http4s._, org.http4s.implicits._, org.http4s.client._
 import cats.effect._, cats._, cats.data._, sup.data._
 
 implicit val client: Client[IO] = Client.fromHttpApp(HttpApp.notFound[IO])
  
+//you'll most likely define this implicit only once per app
+implicit def entityEncoder[A: Encoder]: EntityEncoder[IO, A] = jsonEncoderOf
+
 val healthcheck: HealthCheck[IO, Id] = statusCodeHealthCheck(Request[IO]())
 
 val routes = healthCheckRoutes(healthcheck)
@@ -52,5 +55,7 @@ reportRoutes.orNotFound.run(Request(uri = Uri.uri("/health-check"))).flatMap(_.a
 There's a way to build a healthcheck out of a request to a remote one:
 
 ```tut:book
+implicit val decoder: EntityDecoder[IO, HealthResult[Id]] = jsonOf
+
 val remoteCheck = remoteHealthCheck(Request[IO]())
 ```

--- a/microsite/src/main/tut/guide/http4s-circe.md
+++ b/microsite/src/main/tut/guide/http4s-circe.md
@@ -26,14 +26,11 @@ The circe module provides circe `Encoder`/`Decoder` instances for all the import
 so you can use them together with `http4s-circe` and bundle the whole thing up:
 
 ```tut:book
-import io.circe._, org.http4s.circe._, org.http4s._, org.http4s.implicits._, org.http4s.client._
+import io.circe._, org.http4s.circe._, org.http4s._, org.http4s.implicits._, org.http4s.client._, org.http4s.circe.CirceEntityEncoder._, org.http4s.circe.CirceEntityDecoder._
 import cats.effect._, cats._, cats.data._, sup.data._
 
 implicit val client: Client[IO] = Client.fromHttpApp(HttpApp.notFound[IO])
  
-//you'll most likely define this implicit only once per app
-implicit def entityEncoder[A: Encoder]: EntityEncoder[IO, A] = jsonEncoderOf
-
 val healthcheck: HealthCheck[IO, Id] = statusCodeHealthCheck(Request[IO]())
 
 val routes = healthCheckRoutes(healthcheck)
@@ -55,7 +52,5 @@ reportRoutes.orNotFound.run(Request(uri = Uri.uri("/health-check"))).flatMap(_.a
 There's a way to build a healthcheck out of a request to a remote one:
 
 ```tut:book
-implicit val decoder: EntityDecoder[IO, HealthResult[Id]] = jsonOf
-
 val remoteCheck = remoteHealthCheck(Request[IO]())
 ```

--- a/modules/circe/src/main/scala/sup/modules/circe.scala
+++ b/modules/circe/src/main/scala/sup/modules/circe.scala
@@ -1,9 +1,13 @@
 package sup.modules
 
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.{Decoder, Encoder}
-import sup.data.{Report, Tagged}
-import sup.{Health, HealthResult}
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.Decoder
+import io.circe.Encoder
+import sup.data.Report
+import sup.data.Tagged
+import sup.Health
+import sup.HealthResult
 
 object circe {
   implicit val healthCirceEncoder: Encoder[Health] = Encoder[String].contramap(_.toString)

--- a/modules/core/src/main/scala/sup/HealthResult.scala
+++ b/modules/core/src/main/scala/sup/HealthResult.scala
@@ -3,7 +3,10 @@ package sup
 import cats.implicits._
 import cats.kernel.Monoid
 import cats.tagless.FunctorK
-import cats.{~>, Applicative, Eq, Id}
+import cats.~>
+import cats.Applicative
+import cats.Eq
+import cats.Id
 import sup.data.Tagged
 
 final case class HealthResult[H[_]](value: H[Health]) extends AnyVal {
@@ -13,7 +16,7 @@ final case class HealthResult[H[_]](value: H[Health]) extends AnyVal {
 object HealthResult {
   def const[H[_]: Applicative](health: Health): HealthResult[H] = HealthResult(health.pure[H])
 
-  val one: Health => HealthResult[Id]                                   = HealthResult[Id]
+  val one: Health => HealthResult[Id] = HealthResult[Id]
   def tagged[Tag](tag: Tag, head: Health): HealthResult[Tagged[Tag, ?]] = HealthResult(Tagged(tag, head))
 
   implicit val functorK: FunctorK[HealthResult] = new FunctorK[HealthResult] {

--- a/modules/core/src/main/scala/sup/data/HealthReporter.scala
+++ b/modules/core/src/main/scala/sup/data/HealthReporter.scala
@@ -2,9 +2,12 @@ package sup.data
 
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.kernel.Semigroup
-import cats.{Apply, Functor, NonEmptyTraverse, Parallel, Reducible}
-import cats.temp.par._
+import cats.Apply
+import cats.Functor
+import cats.NonEmptyParallel
+import cats.NonEmptyTraverse
+import cats.Parallel
+import cats.Reducible
 import sup._
 
 object HealthReporter {
@@ -12,9 +15,7 @@ object HealthReporter {
   /**
     * Equivalent to [[wrapChecks]] for G = NonEmptyList, with more pleasant syntax.
     * */
-  def fromChecks[F[_]: Apply, H[_]: Reducible](first: HealthCheck[F, H], rest: HealthCheck[F, H]*)(
-    implicit M: Semigroup[Health]
-  ): HealthReporter[F, NonEmptyList, H] =
+  def fromChecks[F[_]: Apply, H[_]: Reducible](first: HealthCheck[F, H], rest: HealthCheck[F, H]*): HealthReporter[F, NonEmptyList, H] =
     wrapChecks(NonEmptyList(first, rest.toList))
 
   /**
@@ -23,12 +24,11 @@ object HealthReporter {
     *
     * e.g. if all checks need to return Healthy for the whole thing to be healthy, use [[Health.allHealthyCommutativeMonoid]].
     */
-  def wrapChecks[F[_]: Apply, G[_]: NonEmptyTraverse, H[_]: Reducible](
-    checks: G[HealthCheck[F, H]]
-  )(implicit M: Semigroup[Health]): HealthReporter[F, G, H] = HealthCheck.liftF {
+  def wrapChecks[F[_]: Apply, G[_]: NonEmptyTraverse, H[_]: Reducible](checks: G[HealthCheck[F, H]]): HealthReporter[F, G, H] =
+    HealthCheck.liftF {
 
-    checks.nonEmptyTraverse(_.check).map(fromResults[G, H])
-  }
+      checks.nonEmptyTraverse(_.check).map(fromResults[G, H])
+    }
 
   /**
     * Constructs a healthcheck from a non-empty structure G of healthchecks that are run in parallel.
@@ -36,16 +36,13 @@ object HealthReporter {
     *
     * e.g. if all checks need to return Healthy for the whole thing to be healthy, use [[Health.allHealthyCommutativeMonoid]].
     */
-  def parWrapChecks[F[_]: NonEmptyPar: Functor, G[_]: NonEmptyTraverse, H[_]: Reducible](
+  def parWrapChecks[F[_]: NonEmptyParallel: Functor, G[_]: NonEmptyTraverse, H[_]: Reducible](
     checks: G[HealthCheck[F, H]]
-  )(implicit M: Semigroup[Health]): HealthReporter[F, G, H] = HealthCheck.liftF {
+  ): HealthReporter[F, G, H] = HealthCheck.liftF {
 
     Parallel.parNonEmptyTraverse(checks)(_.check).map(fromResults[G, H])
   }
 
-  def fromResults[G[_]: Reducible: Functor, H[_]: Reducible](
-    results: G[HealthResult[H]]
-  )(implicit M: Semigroup[Health]): HealthResult[Report[G, H, ?]] = {
+  def fromResults[G[_]: Reducible: Functor, H[_]: Reducible](results: G[HealthResult[H]]): HealthResult[Report[G, H, ?]] =
     HealthResult(Report.fromResults[G, H, Health](results.map(_.value)))
-  }
 }

--- a/modules/core/src/main/scala/sup/mods.scala
+++ b/modules/core/src/main/scala/sup/mods.scala
@@ -1,7 +1,7 @@
 package sup
 
 import cats.data.{EitherK, Tuple2K}
-import cats.{~>, Applicative, ApplicativeError, FlatMap, Functor, Id, Semigroup}
+import cats.{Applicative, ApplicativeError, FlatMap, Functor, Id, Semigroup}
 import cats.effect.{Concurrent, Timer}
 
 import scala.concurrent.duration.FiniteDuration
@@ -20,8 +20,10 @@ object mods {
   /**
     * Fallback to the provided value in case the check takes longer than `duration`.
     * */
-  def timeoutToDefault[F[_]: Concurrent: Timer, H[_]: Applicative](default: Health,
-                                                                   duration: FiniteDuration): HealthCheckEndoMod[F, H] =
+  def timeoutToDefault[F[_]: Concurrent: Timer, H[_]: Applicative](
+    default: Health,
+    duration: FiniteDuration
+  ): HealthCheckEndoMod[F, H] =
     _.transform {
       _.timeoutTo(duration, HealthResult(default.pure[H]).pure[F])
     }

--- a/modules/core/src/test/scala/sup/BaseIOTest.scala
+++ b/modules/core/src/test/scala/sup/BaseIOTest.scala
@@ -1,12 +1,15 @@
 package sup
-import cats.effect.{ConcurrentEffect, Timer}
+
+import cats.effect.ConcurrentEffect
+import cats.effect.Timer
 import org.scalatest.compatible.Assertion
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import cats.effect.implicits._
+import org.scalatest.wordspec.AnyWordSpec
 
-trait BaseIOTest extends WordSpec with Matchers {
-  def ioTimeout: FiniteDuration                                         = 5.seconds
+trait BaseIOTest extends AnyWordSpec with Matchers {
+  def ioTimeout: FiniteDuration = 5.seconds
   def runIO[F[_]: ConcurrentEffect: Timer](io: F[Assertion]): Assertion = io.timeout(ioTimeout).toIO.unsafeRunSync()
 }

--- a/modules/core/src/test/scala/sup/HealthCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthCatsInstancesTests.scala
@@ -3,7 +3,6 @@ package sup
 import cats.kernel.laws.discipline.CommutativeMonoidTests
 import cats.kernel.laws.discipline.EqTests
 import cats.tests.CatsSuite
-import org.scalacheck.magnolia._
 
 class HealthCatsInstancesTests extends CatsSuite {
   import ScalacheckInstances._

--- a/modules/core/src/test/scala/sup/HealthCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthCatsInstancesTests.scala
@@ -6,6 +6,8 @@ import cats.tests.CatsSuite
 import org.scalacheck.magnolia._
 
 class HealthCatsInstancesTests extends CatsSuite {
+  import ScalacheckInstances._
+
   checkAll("Eq[Health]", EqTests[Health].eqv)
   checkAll("CommutativeMonoid[Health]", CommutativeMonoidTests[Health].commutativeMonoid)
 }

--- a/modules/core/src/test/scala/sup/HealthCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthCatsInstancesTests.scala
@@ -1,8 +1,9 @@
 package sup
 
-import cats.kernel.laws.discipline.{CommutativeMonoidTests, EqTests}
+import cats.kernel.laws.discipline.CommutativeMonoidTests
+import cats.kernel.laws.discipline.EqTests
 import cats.tests.CatsSuite
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.magnolia._
 
 class HealthCatsInstancesTests extends CatsSuite {
   checkAll("Eq[Health]", EqTests[Health].eqv)

--- a/modules/core/src/test/scala/sup/HealthCheckCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthCheckCatsInstancesTests.scala
@@ -1,24 +1,24 @@
 package sup
-import cats.kernel.laws.discipline.{EqTests, MonoidTests}
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.MonoidTests
 import cats.tagless.laws.discipline.FunctorKTests
 import cats.tests.CatsSuite
-import org.scalacheck.{Arbitrary, Cogen}
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.magnolia._
 
 import scala.util.Try
 
 import CatsTaglessInstances._
 
 class HealthCheckCatsInstancesTests extends CatsSuite {
-  implicit def arbitraryHealthCheck[F[_], H[_]](
-    implicit A: Arbitrary[F[HealthResult[H]]]): Arbitrary[HealthCheck[F, H]] =
+  implicit def arbitraryHealthCheck[F[_], H[_]](implicit A: Arbitrary[F[HealthResult[H]]]): Arbitrary[HealthCheck[F, H]] =
     Arbitrary(A.arbitrary.map(HealthCheck.liftF))
 
   implicit def cogenHealthCheck[F[_], H[_]](implicit C: Cogen[F[HealthResult[H]]]): Cogen[HealthCheck[F, H]] =
     C.contramap(_.check)
 
-  checkAll("FunctorK[HealthCheck[Option, ?[_]]",
-           FunctorKTests[HealthCheck[Option, ?[_]]].functorK[Try, Option, List, Int])
+  checkAll("FunctorK[HealthCheck[Option, ?[_]]", FunctorKTests[HealthCheck[Option, ?[_]]].functorK[Try, Option, List, Int])
   checkAll("Monoid[HealthCheck[Try, Option]]", MonoidTests[HealthCheck[Try, Option]].monoid)
   checkAll("Eq[HealthCheck[Try, Option]]", EqTests[HealthCheck[Try, Option]].eqv)
 }

--- a/modules/core/src/test/scala/sup/HealthCheckCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthCheckCatsInstancesTests.scala
@@ -3,7 +3,6 @@ import cats.kernel.laws.discipline.EqTests
 import cats.kernel.laws.discipline.MonoidTests
 import cats.tagless.laws.discipline.FunctorKTests
 import cats.tests.CatsSuite
-import org.scalacheck.magnolia._
 
 import scala.util.Try
 

--- a/modules/core/src/test/scala/sup/HealthCheckCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthCheckCatsInstancesTests.scala
@@ -3,8 +3,6 @@ import cats.kernel.laws.discipline.EqTests
 import cats.kernel.laws.discipline.MonoidTests
 import cats.tagless.laws.discipline.FunctorKTests
 import cats.tests.CatsSuite
-import org.scalacheck.Arbitrary
-import org.scalacheck.Cogen
 import org.scalacheck.magnolia._
 
 import scala.util.Try
@@ -12,11 +10,7 @@ import scala.util.Try
 import CatsTaglessInstances._
 
 class HealthCheckCatsInstancesTests extends CatsSuite {
-  implicit def arbitraryHealthCheck[F[_], H[_]](implicit A: Arbitrary[F[HealthResult[H]]]): Arbitrary[HealthCheck[F, H]] =
-    Arbitrary(A.arbitrary.map(HealthCheck.liftF))
-
-  implicit def cogenHealthCheck[F[_], H[_]](implicit C: Cogen[F[HealthResult[H]]]): Cogen[HealthCheck[F, H]] =
-    C.contramap(_.check)
+  import ScalacheckInstances._
 
   checkAll("FunctorK[HealthCheck[Option, ?[_]]", FunctorKTests[HealthCheck[Option, ?[_]]].functorK[Try, Option, List, Int])
   checkAll("Monoid[HealthCheck[Try, Option]]", MonoidTests[HealthCheck[Try, Option]].monoid)

--- a/modules/core/src/test/scala/sup/HealthResultCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthResultCatsInstancesTests.scala
@@ -9,6 +9,8 @@ import org.scalacheck.magnolia._
 import scala.util.Try
 
 class HealthResultCatsInstancesTests extends CatsSuite {
+  import ScalacheckInstances._
+
   checkAll("FunctorK[HealthResult]", FunctorKTests[HealthResult].functorK[Try, Option, List, Int])
   checkAll("Monoid[HealthResult[Option]]", MonoidTests[HealthResult[Option]].monoid)
   checkAll("Eq[HealthResult[Option]]", EqTests[HealthResult[Option]].eqv)

--- a/modules/core/src/test/scala/sup/HealthResultCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthResultCatsInstancesTests.scala
@@ -1,10 +1,11 @@
 package sup
 
-import cats.kernel.laws.discipline.{EqTests, MonoidTests}
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.MonoidTests
 import cats.tagless.laws.discipline.FunctorKTests
 import cats.tests.CatsSuite
 import sup.CatsTaglessInstances._
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.magnolia._
 import scala.util.Try
 
 class HealthResultCatsInstancesTests extends CatsSuite {

--- a/modules/core/src/test/scala/sup/HealthResultCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/HealthResultCatsInstancesTests.scala
@@ -5,7 +5,6 @@ import cats.kernel.laws.discipline.MonoidTests
 import cats.tagless.laws.discipline.FunctorKTests
 import cats.tests.CatsSuite
 import sup.CatsTaglessInstances._
-import org.scalacheck.magnolia._
 import scala.util.Try
 
 class HealthResultCatsInstancesTests extends CatsSuite {

--- a/modules/core/src/test/scala/sup/ScalacheckInstances.scala
+++ b/modules/core/src/test/scala/sup/ScalacheckInstances.scala
@@ -5,6 +5,17 @@ import org.scalacheck.Arbitrary
 import sup.data.Tagged
 
 object ScalacheckInstances {
+  implicit def arbitraryTagged[Tag: Arbitrary, E: Arbitrary]: Arbitrary[Tagged[Tag, E]] = Arbitrary {
+    for {
+      tag  <- Arbitrary.arbitrary[Tag]
+      elem <- Arbitrary.arbitrary[E]
+    } yield Tagged(tag, elem)
+  }
+  implicit def arbitraryHealthResult[H[_]](implicit F: Arbitrary[H[Health]]): Arbitrary[HealthResult[H]] = Arbitrary {
+    F.arbitrary.map(HealthResult(_))
+  }
+
+  implicit val arbitraryHealth: Arbitrary[Health] = Arbitrary(Arbitrary.arbitrary[Boolean].map(Health.fromBoolean))
   implicit val cogenHealth: Cogen[Health] = Cogen.cogenBoolean.contramap(_.isHealthy)
 
   implicit def arbitraryHealthCheck[F[_], H[_]](implicit A: Arbitrary[F[HealthResult[H]]]): Arbitrary[HealthCheck[F, H]] =

--- a/modules/core/src/test/scala/sup/ScalacheckInstances.scala
+++ b/modules/core/src/test/scala/sup/ScalacheckInstances.scala
@@ -1,0 +1,20 @@
+package sup
+
+import org.scalacheck.Cogen
+import org.scalacheck.Arbitrary
+import sup.data.Tagged
+
+object ScalacheckInstances {
+  implicit val cogenHealth: Cogen[Health] = Cogen.cogenBoolean.contramap(_.isHealthy)
+
+  implicit def arbitraryHealthCheck[F[_], H[_]](implicit A: Arbitrary[F[HealthResult[H]]]): Arbitrary[HealthCheck[F, H]] =
+    Arbitrary(A.arbitrary.map(HealthCheck.liftF))
+
+  implicit def cogenHealthResult[H[_]](implicit C: Cogen[H[Health]]): Cogen[HealthResult[H]] = C.contramap(_.value)
+  implicit def cogenHealthCheck[F[_], H[_]](implicit C: Cogen[F[HealthResult[H]]]): Cogen[HealthCheck[F, H]] =
+    C.contramap(_.check)
+
+  implicit def cogenTagged[Tag: Cogen, H: Cogen]: Cogen[Tagged[Tag, H]] = Cogen[(Tag, H)].contramap { tagged =>
+    (tagged.tag, tagged.health)
+  }
+}

--- a/modules/core/src/test/scala/sup/TaggedCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/TaggedCatsInstancesTests.scala
@@ -4,7 +4,7 @@ import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline._
 import cats.tests.CatsSuite
 import sup.data.Tagged
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.magnolia._
 
 class TaggedCatsInstancesTests extends CatsSuite {
   checkAll("Reducible[Tagged[String, ?]]", ReducibleTests[Tagged[String, ?]].reducible[List, Int, Int])

--- a/modules/core/src/test/scala/sup/TaggedCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/TaggedCatsInstancesTests.scala
@@ -7,6 +7,8 @@ import sup.data.Tagged
 import org.scalacheck.magnolia._
 
 class TaggedCatsInstancesTests extends CatsSuite {
+  import ScalacheckInstances._
+
   checkAll("Reducible[Tagged[String, ?]]", ReducibleTests[Tagged[String, ?]].reducible[List, Int, Int])
   checkAll("Eq[Tagged[String, Int]]", EqTests[Tagged[String, Int]].eqv)
 }

--- a/modules/core/src/test/scala/sup/TaggedCatsInstancesTests.scala
+++ b/modules/core/src/test/scala/sup/TaggedCatsInstancesTests.scala
@@ -4,7 +4,6 @@ import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline._
 import cats.tests.CatsSuite
 import sup.data.Tagged
-import org.scalacheck.magnolia._
 
 class TaggedCatsInstancesTests extends CatsSuite {
   import ScalacheckInstances._

--- a/modules/doobie/src/main/scala/sup/modules/doobie.scala
+++ b/modules/doobie/src/main/scala/sup/modules/doobie.scala
@@ -1,9 +1,10 @@
 package sup.modules
 
-import cats.{Id, Monad}
-import eu.timepit.refined.types.numeric.PosInt
+import cats.Id
 import sup.HealthCheck
 import cats.effect.Bracket
+import scala.concurrent.duration._
+import cats.implicits._
 
 object doobie {
   import _root_.doobie._
@@ -16,9 +17,9 @@ object doobie {
     * Note: Errors aren't recovered in this healthcheck. If you want error handling,
     * consider using [[HealthCheck.through]] with [[sup.mods.recoverToSick]].
     * */
-  def connectionCheck[F[_]: Bracket[?[_], Throwable]](xa: Transactor[F])(timeoutSeconds: Option[PosInt]): HealthCheck[F, Id] = {
+  def connectionCheck[F[_]: Bracket[?[_], Throwable]](xa: Transactor[F])(timeout: Option[FiniteDuration]): HealthCheck[F, Id] = {
     //zero means infinite in JDBC
-    val actualTimeoutSeconds = timeoutSeconds.fold(0)(_.value)
+    val actualTimeoutSeconds = timeout.foldMap(_.toSeconds.toInt)
 
     HealthCheck.liftFBoolean {
       FC.isValid(actualTimeoutSeconds).transact(xa)

--- a/modules/doobie/src/test/scala/sup/DoobieCheckSpec.scala
+++ b/modules/doobie/src/test/scala/sup/DoobieCheckSpec.scala
@@ -1,10 +1,14 @@
 package sup
 
 import _root_.doobie.Transactor
-import cats.effect.{Async, ContextShift, IO, Timer}
-import eu.timepit.refined.auto._
-import org.scalatest.{Matchers, WordSpec}
-
+import cats.effect.Async
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Timer
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+import scala.concurrent.duration._
+import cats.implicits._
 import scala.concurrent.ExecutionContext
 
 class DoobieCheckSpec extends BaseIOTest {
@@ -16,12 +20,12 @@ class DoobieCheckSpec extends BaseIOTest {
     Transactor.fromDriverManager[F]("org.h2.Driver", "jdbcfoobarnope")
 
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-  implicit val timer: Timer[IO]     = IO.timer(ExecutionContext.global)
+  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   "IO H2 check" when {
     "the database responds before the timeout" should {
       "be Healthy" in runIO {
-        val healthCheck = modules.doobie.connectionCheck(goodTransactor[IO])(timeoutSeconds = Some(5))
+        val healthCheck = modules.doobie.connectionCheck(goodTransactor[IO])(timeout = 5.seconds.some)
 
         healthCheck.check.map {
           _.value shouldBe Health.Healthy
@@ -31,7 +35,7 @@ class DoobieCheckSpec extends BaseIOTest {
 
     "there is no timeout" should {
       "be Healthy" in runIO {
-        val healthCheck = modules.doobie.connectionCheck(goodTransactor[IO])(timeoutSeconds = None)
+        val healthCheck = modules.doobie.connectionCheck(goodTransactor[IO])(timeout = none)
 
         healthCheck.check.map {
           _.value shouldBe Health.Healthy

--- a/modules/doobie/src/test/scala/sup/DoobieCheckSpec.scala
+++ b/modules/doobie/src/test/scala/sup/DoobieCheckSpec.scala
@@ -5,8 +5,6 @@ import cats.effect.Async
 import cats.effect.ContextShift
 import cats.effect.IO
 import cats.effect.Timer
-import org.scalatest.Matchers
-import org.scalatest.WordSpec
 import scala.concurrent.duration._
 import cats.implicits._
 import scala.concurrent.ExecutionContext

--- a/modules/redis/src/test/scala/sup/RedisCheckSpec.scala
+++ b/modules/redis/src/test/scala/sup/RedisCheckSpec.scala
@@ -2,10 +2,11 @@ package sup
 
 import cats.implicits._
 import dev.profunktor.redis4cats.algebra.Ping
-import org.scalatest.{Matchers, WordSpec}
 import sup.modules.redis
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class RedisCheckSpec extends WordSpec with Matchers {
+class RedisCheckSpec extends AnyWordSpec with Matchers {
   "Either check" when {
     "Right" should {
       "be Healthy" in {

--- a/project/Options.scala
+++ b/project/Options.scala
@@ -1,51 +1,76 @@
+import sbt.Keys.{scalaVersion, scalacOptions}
+
 object Options {
 
   //from https://tpolecat.github.io/2017/04/25/scalac-flags.html
-  val all = Seq(
-    "-deprecation", // Emit warning and location for usages of deprecated APIs.
-    "-encoding",
-    "utf-8", // Specify character encoding used by source files.
-    "-explaintypes", // Explain type errors in more detail.
-    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
-    "-language:experimental.macros", // Allow macro definition (besides implementation and application)
-    "-language:higherKinds", // Allow higher-kinded types
-    "-language:implicitConversions", // Allow definition of implicit functions called views
-    "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfuture", // Turn on future language features.
-    "-Xlint:adapted-args",              // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-//    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error. todo 2.12+
-    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
-    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit", // Option.apply used implicit view.
-    "-Xlint:package-object-classes", // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match", // Pattern match may not be typesafe.
-    "-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-    "-Ypartial-unification", // Enable partial unification in type constructor inference
-    "-Ywarn-dead-code",      // Warn when dead code is identified.
-//    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined. todo 2.12+
-    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-    "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Ywarn-nullary-unit",  // Warn when nullary methods return Unit.
-    "-Ywarn-numeric-widen", // Warn when numerics are widened.
-//    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused. todo 2.12+
-//    "-Ywarn-unused:imports", // Warn if an import selector is not referenced. todo 2.12+
-//    "-Ywarn-unused:locals", // Warn if a local definition is unused. todo 2.12+
-//    "-Ywarn-unused:params", // Warn if a value parameter is unused. todo 2.12+
-//    "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused. todo 2.12+
-//    "-Ywarn-unused:privates", // Warn if a private member is unused. todo 2.12+
-    "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
-  )
+  def all(scalaVersion: String) = {
+    val scala_2_12Options = Set(
+      "-deprecation",                     // Emit warning and location for usages of deprecated APIs.
+      "-explaintypes",                    // Explain type errors in more detail.
+      "-feature",                         // Emit warning and location for usages of features that should be imported explicitly.
+      "-language:existentials",           // Existential types (besides wildcard types) can be written and inferred
+      "-language:experimental.macros",    // Allow macro definition (besides implementation and application)
+      "-language:higherKinds",            // Allow higher-kinded types
+      "-language:implicitConversions",    // Allow definition of implicit functions called views
+      "-unchecked",                       // Enable additional warnings where generated code depends on assumptions.
+      "-Xcheckinit",                      // Wrap field accessors to throw an exception on uninitialized access.
+      "-Xfuture",                         // Turn on future language features.
+      "-Xlint:adapted-args",              // Warn if an argument list is modified to match the receiver.
+      "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+      "-Xlint:delayedinit-select",        // Selecting member of DelayedInit.
+      "-Xlint:doc-detached",              // A Scaladoc comment appears to be detached from its element.
+      "-Xlint:inaccessible",              // Warn about inaccessible types in method signatures.
+      "-Xlint:infer-any",                 // Warn when a type argument is inferred to be `Any`.
+      "-Xlint:missing-interpolator",      // A string literal appears to be missing an interpolator id.
+      "-Xlint:nullary-override",          // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Xlint:nullary-unit",              // Warn when nullary methods return Unit.
+      "-Xlint:option-implicit",           // Option.apply used implicit view.
+      "-Xlint:package-object-classes",    // Class or object defined in package object.
+      "-Xlint:poly-implicit-overload",    // Parameterized overloaded implicit methods are not visible as view bounds.
+      "-Xlint:private-shadow",            // A private field (or class parameter) shadows a superclass field.
+      "-Xlint:stars-align",               // Pattern sequence wildcard must align with sequence component.
+      "-Xlint:type-parameter-shadow",     // A local type parameter shadows a type already in scope.
+      "-Xlint:unsound-match",             // Pattern match may not be typesafe.
+      "-Yno-adapted-args",                // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      "-Ypartial-unification",            // Enable partial unification in type constructor inference
+      "-Ywarn-dead-code",                 // Warn when dead code is identified.
+      "-Ywarn-inaccessible",              // Warn about inaccessible types in method signatures.
+      "-Ywarn-infer-any",                 // Warn when a type argument is inferred to be `Any`.
+      "-Ywarn-nullary-override",          // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Ywarn-nullary-unit",              // Warn when nullary methods return Unit.
+      "-Ywarn-numeric-widen",             // Warn when numerics are widened.
+      "-Ywarn-value-discard",             // Warn when non-Unit expression results are unused.
+      "-Xlint:constant",                  // Evaluation of a constant arithmetic expression results in an error.
+      "-Ywarn-extra-implicit",            // Warn when more than one implicit parameter section is defined.
+      "-Ywarn-unused:implicits",          // Warn if an implicit parameter is unused.
+      "-Ywarn-unused:imports",            // Warn if an import selector is not referenced.
+      "-Ywarn-unused:locals",             // Warn if a local definition is unused.
+      "-Ywarn-unused:params",             // Warn if a value parameter is unused.
+      "-Ywarn-unused:patvars",            // Warn if a variable bound in a pattern is unused.
+      "-Ywarn-unused:privates"            // Warn if a private member is unused.
+    )
+
+    val scala_2_13Options = scala_2_12Options -- Set(
+      "-Xlint:by-name-right-associative",
+      "-Xlint:unsound-match",
+      "-Yno-adapted-args",
+      "-Ywarn-nullary-unit",
+      "-Ywarn-inaccessible",
+      "-Ypartial-unification",
+      "-Ywarn-infer-any",
+      "-Ywarn-nullary-override",
+      "-Ywarn-unused:params",
+      "-Xlint:type-parameter-shadow",
+      "-Xfuture",
+      "-deprecation"
+    ) ++ List("-Xlint:deprecation")
+
+    (scalaVersion match {
+      case v if v.startsWith("2.12") => scala_2_12Options
+      case v if v.startsWith("2.13") => scala_2_13Options
+    }).toList ++ List(
+      "-encoding",
+      "utf-8" // Specify character encoding used by source files.
+    )
+  }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.3.2
+# downgraded until https://github.com/jrudolph/sbt-dependency-graph/issues/178 is fixed
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
-addSbtPlugin("com.47deg"    % "sbt-microsites" % "0.9.6")
+addSbtPlugin("com.47deg"    % "sbt-microsites" % "0.9.4") //update after sbt is bumped to 1.3.x
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo"  % "0.9.0")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
-
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0") //this too

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.2")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
 addSbtPlugin("com.47deg"    % "sbt-microsites" % "0.9.6")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo"  % "0.9.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")


### PR DESCRIPTION
TODO:

- [ ] Stable http4s with a dependency on CE 2.0.0 final (later)
- [x] ~Cogen derivation (coming soon to scalacheck-magnolia)~ manual Cogen instances where needed
- [x] Stable doobie
- [x] cats-tagless with a dependency on cats 2.0.0 final
- [x] check if microsite builds

For release notes:
- refined was removed in favor of a FiniteDuration in the doobie module
- mention changed signatures that used to take a semigroup instance

Closes #107 