### PR TITLE
Downgrade Scala 3, upgrade Scala 2 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.1]
+        scala: [2.12.14, 2.13.6, 3.0.0]
         java: [graalvm-ce-java11@21.0.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13]
+        scala: [2.12.14]
         java: [graalvm-ce-java11@21.0.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -100,32 +100,32 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.13)
+      - name: Download target directories (2.12.14)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.12.13-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.13)
+      - name: Inflate target directories (2.12.14)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.5)
+      - name: Download target directories (2.13.6)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.13.5-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.6-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.5)
+      - name: Inflate target directories (2.13.6)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.1)
+      - name: Download target directories (3.0.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.0.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.0.1)
+      - name: Inflate target directories (3.0.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import sbt.internal.ProjectMatrix
 
-val Scala_212 = "2.12.13"
-val Scala_213 = "2.13.5"
-val Scala_3 = "3.0.1"
+val Scala_212 = "2.12.14"
+val Scala_213 = "2.13.6"
+val Scala_3 = "3.0.0"
 
 val scala2Only = Seq(Scala_212, Scala_213)
 val scala2And3 = scala2Only :+ Scala_3


### PR DESCRIPTION
3.0.1 fails while publishing docs, 2.12 and 2.13 have newer versions (that hopefully don't introduce new bugs).

See https://github.com/kubukoz/sup/pull/364#issuecomment-886117739