### PR TITLE
Don't create GH build job matrix for crossScalaVersions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.14, 2.13.6, 3.0.0]
+        scala: [2.12.14]
         java: [graalvm-ce-java11@21.0.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -106,26 +106,6 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.6)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-2.13.6-${{ matrix.java }}
-
-      - name: Inflate target directories (2.13.6)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.0.0)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-3.0.0-${{ matrix.java }}
-
-      - name: Inflate target directories (3.0.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ val GraalVM11 = "graalvm-ce-java11@21.0.0"
 
 ThisBuild / scalaVersion := Scala_212
 ThisBuild / crossScalaVersions := Seq(Scala_212, Scala_213, Scala_3)
+// Using sbt-projectmatrix, Scala versions are mapped to different modules, hence we only need to run CI on one
+ThisBuild / githubWorkflowScalaVersions := Seq(Scala_212)
 ThisBuild / githubWorkflowJavaVersions := Seq(GraalVM11)
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("test", "mimaReportBinaryIssues"))


### PR DESCRIPTION
As `sbt-projectmatrix` maps the different Scala versions to different modules, no build matrix may be defined for them in GH as it would to redundant compilations. Should resolve https://github.com/kubukoz/sup/pull/364#issuecomment-886125383

PS: Could you release a milestone with Scala 3? 0.10.0-M1 or so? Would not only be a good test CI fully works, but also help me at $WORK…