### PR TITLE
Add fs2-kafka health check (0.8.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - run: sbt ++${{ matrix.scala }} test mimaReportBinaryIssues
 
       - name: Compress target directories
-        run: tar cf targets.tar modules/sttp/target modules/http4s/target modules/scalacache/target modules/doobie/target modules/log4cats/target modules/cassandra/target modules/akka-http/target modules/circe/target modules/http4s-client/target modules/redis/target modules/core/target target project/target
+        run: tar cf targets.tar modules/sttp/target modules/fs2-kafka/target modules/http4s/target modules/scalacache/target modules/doobie/target modules/log4cats/target modules/cassandra/target modules/akka-http/target modules/circe/target modules/http4s-client/target modules/redis/target modules/core/target target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ val catsTaglessVersion = "0.11"
 val doobieVersion = "0.9.4"
 val catsVersion = "2.6.1"
 val scalacacheVersion = "0.28.0"
+val fs2KafkaVersion = "1.8.0"
 val kindProjectorVersion = "0.11.3"
 val fs2RedisVersion = "0.10.3"
 val h2Version = "1.4.200"
@@ -172,7 +173,31 @@ val sttp = module("sttp")
   )
   .dependsOn(core)
 
-val allModules = List(core, scalacache, doobie, redis, log4cats, http4s, http4sClient, akkaHttp, circe, sttp, cassandra)
+val kafka = module("fs2-kafka")
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.fd4s" %% "fs2-kafka" % fs2KafkaVersion,
+      "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test,
+      "com.dimafeng" %% "testcontainers-scala-kafka" % testcontainersScalaVersion % Test
+    ),
+    mimaPreviousArtifacts := Set()
+  )
+  .dependsOn(core % "compile->compile;test->test")
+
+val allModules = List(
+  core,
+  scalacache,
+  doobie,
+  redis,
+  log4cats,
+  http4s,
+  http4sClient,
+  akkaHttp,
+  circe,
+  sttp,
+  cassandra,
+  kafka
+)
 
 val lastStableVersion = settingKey[String]("Last tagged version")
 

--- a/modules/fs2-kafka/src/main/scala/sup/modules/kafka.scala
+++ b/modules/fs2-kafka/src/main/scala/sup/modules/kafka.scala
@@ -1,0 +1,36 @@
+package sup.modules
+
+import cats.Id
+import cats.effect.{Concurrent, Timer}
+import cats.syntax.applicativeError._
+import cats.syntax.functor._
+import fs2.kafka.KafkaAdminClient
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import sup.{mods, Health, HealthCheck, HealthResult}
+
+import scala.concurrent.duration.FiniteDuration
+
+object kafka {
+
+  def clusterCheck[F[_]: Concurrent: Timer](client: KafkaAdminClient[F], timeout: FiniteDuration): HealthCheck[F, Id] =
+    HealthCheck
+      .liftF {
+        client.describeCluster.clusterId.as(HealthResult.one(Health.healthy))
+      }
+      .through(mods.timeoutToSick(timeout))
+
+  def topicsCheck[F[_]: Concurrent: Timer](
+    client: KafkaAdminClient[F],
+    timeout: FiniteDuration
+  )(
+    topicName: String*
+  ): HealthCheck[F, Id] =
+    HealthCheck
+      .liftFBoolean {
+        client.describeTopics(topicName.toList).map(_.keySet.exists(topicName.contains)).recover {
+          case _: UnknownTopicOrPartitionException => false
+        }
+      }
+      .through(mods.timeoutToSick(timeout))
+
+}

--- a/modules/fs2-kafka/src/main/scala/sup/modules/kafka.scala
+++ b/modules/fs2-kafka/src/main/scala/sup/modules/kafka.scala
@@ -1,36 +1,26 @@
 package sup.modules
 
-import cats.Id
-import cats.effect.{Concurrent, Timer}
 import cats.syntax.applicativeError._
 import cats.syntax.functor._
+import cats.{Id, MonadThrow}
 import fs2.kafka.KafkaAdminClient
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
-import sup.{mods, Health, HealthCheck, HealthResult}
-
-import scala.concurrent.duration.FiniteDuration
+import org.apache.kafka.common.errors.{TimeoutException, UnknownTopicOrPartitionException}
+import sup.{Health, HealthCheck, HealthResult}
 
 object kafka {
 
-  def clusterCheck[F[_]: Concurrent: Timer](client: KafkaAdminClient[F], timeout: FiniteDuration): HealthCheck[F, Id] =
-    HealthCheck
-      .liftF {
-        client.describeCluster.clusterId.as(HealthResult.one(Health.healthy))
+  def clusterCheck[F[_]: MonadThrow](client: KafkaAdminClient[F]): HealthCheck[F, Id] =
+    HealthCheck.liftF {
+      client.describeCluster.clusterId.as(HealthResult.one(Health.healthy)).recover {
+        case _: TimeoutException => HealthResult.one(Health.sick)
       }
-      .through(mods.timeoutToSick(timeout))
+    }
 
-  def topicsCheck[F[_]: Concurrent: Timer](
-    client: KafkaAdminClient[F],
-    timeout: FiniteDuration
-  )(
-    topicName: String*
-  ): HealthCheck[F, Id] =
-    HealthCheck
-      .liftFBoolean {
-        client.describeTopics(topicName.toList).map(_.keySet.exists(topicName.contains)).recover {
-          case _: UnknownTopicOrPartitionException => false
-        }
+  def topicsCheck[F[_]: MonadThrow](client: KafkaAdminClient[F])(topicNames: String*): HealthCheck[F, Id] =
+    HealthCheck.liftFBoolean {
+      client.describeTopics(topicNames.toList).map(result => topicNames.forall(result.keySet.contains)).recover {
+        case _: UnknownTopicOrPartitionException => false
       }
-      .through(mods.timeoutToSick(timeout))
+    }
 
 }

--- a/modules/fs2-kafka/src/test/scala/sup/modules/KafkaCheckSpec.scala
+++ b/modules/fs2-kafka/src/test/scala/sup/modules/KafkaCheckSpec.scala
@@ -1,0 +1,62 @@
+package sup.modules
+
+import cats.effect.{IO, Resource}
+import com.dimafeng.testcontainers.{ForEachTestContainer, KafkaContainer}
+import fs2.kafka.{AdminClientSettings, KafkaAdminClient}
+import org.apache.kafka.clients.admin.NewTopic
+import sup.BaseIOTest
+import sup.modules.kafka.{clusterCheck, topicsCheck}
+
+import java.util.Optional
+import scala.concurrent.duration._
+
+class KafkaCheckSpec extends BaseIOTest with ForEachTestContainer {
+
+  private val kafkaTimeout: FiniteDuration = 2.seconds
+
+  override val container: KafkaContainer = KafkaContainer()
+  override def ioTimeout: FiniteDuration = 30.seconds
+
+  "Kafka health checker" when {
+    "kafka cluster is up and running" should {
+      "return an healthy result" in runIO {
+        createClient.use(client => clusterCheck[IO](client, kafkaTimeout).check.map(h => assert(h.value.isHealthy)))
+      }
+    }
+
+    "kafka cluster is down" should {
+      "return an healthy result" in runIO {
+        createClient.use { client =>
+          IO(container.stop()) *> clusterCheck[IO](client, kafkaTimeout).check.map(h => assert(!h.value.isHealthy))
+        }
+      }
+    }
+
+    "kafka topics exists" should {
+      "return an healthy result" in runIO {
+        createClient.use { client =>
+          val topic1 = new NewTopic("topic-1", Optional.empty[Integer](), Optional.empty[java.lang.Short]())
+          val topic2 = new NewTopic("topic-2", Optional.empty[Integer](), Optional.empty[java.lang.Short]())
+
+          client.createTopics(List(topic1, topic2)) *> topicsCheck[IO](
+            client,
+            kafkaTimeout
+          )(topic1.name(), topic2.name()).check.map(h => assert(h.value.isHealthy))
+        }
+      }
+    }
+
+    "kafka topics does not exists" should {
+      "return an unhealthy result" in runIO {
+        createClient.use { client =>
+          topicsCheck[IO](client, kafkaTimeout)("topic-0").check.map(h => assert(!h.value.isHealthy))
+        }
+      }
+    }
+  }
+
+  private def createClient: Resource[IO, KafkaAdminClient[IO]] = {
+    val settings = AdminClientSettings[IO].withBootstrapServers(container.bootstrapServers)
+    KafkaAdminClient.resource(settings)
+  }
+}


### PR DESCRIPTION
Adds a module to support fs2-kafka for cluster availability and topics existence (0.8.x series).